### PR TITLE
Introduced FIELDARR slot in table-object

### DIFF
--- a/jli.lsp
+++ b/jli.lsp
@@ -4,7 +4,7 @@
 
 ; JLI takes form as a simple array of hash-tables, representing each {},[] encapsulation with an array of hash-tables
 
-; Return-list encapsules a list of :keywords as KEYS, of which entries from the records to return
+; Return-list encapsulates a list of :keywords as KEYS, of which entries from the records to return
 ; No return-list returns all/* (temp function for DEV)
 
 (defun find-in-jli (jli key operator val &optional return-list)

--- a/sql-databases.lsp
+++ b/sql-databases.lsp
@@ -39,7 +39,9 @@
 	 (files		:type integer 	 :initform 0	; Number of files the table is split into
 				:accessor files)
 	 (rowcount	:type integer	 :initform 0	; Number of ROWS the table contains
-				:accessor rowcount)))
+				:accessor rowcount)
+	 (fieldarr	:type t							; An array containing references to the fields, indexed by ROWNUM
+				:accessor fieldarr)))
 
 (defclass schema ()
 	((tables :type hash-table :accessor tables :initform (make-hash-table))))
@@ -92,6 +94,12 @@
 							keytypes))
 		(setf (files table-form) 	(car data-size))
 		(setf (rowcount table-form) (cdr data-size))
+		
+		(setf (fieldarr table-form) (make-array (hash-table-count (fields table-form)) :element-type t))
+		(maphash (lambda (k v)
+			(declare (ignore k))
+			(setf (aref (fieldarr table-form) (rownum v)) v))			; Assign FIELD reference to FIELDARR matching the fields' ROW NUMBER
+			(fields table-form))
 		table-form))
 		
 

--- a/sql-insert.lsp
+++ b/sql-insert.lsp
@@ -9,16 +9,13 @@
 			(table-name (read stream nil nil))
 			(table-fields (fields (gethash table-name 
 				(tables (gethash *in-db* *schemas*)))))
+			(fields	 (fieldarr (gethash table-name 
+				(tables (gethash *in-db* *schemas*)))))
 			(valuelist (read stream nil nil))
 			(fieldnums)
 			(sets	 (make-array 0 :fill-pointer 0 :element-type t :adjustable t))			
-			(fields	 (make-array (hash-table-count table-fields) :element-type t))
-			(fvalues (make-array (hash-table-count table-fields) :element-type t :initial-element 'null)))
-		(declare (ignore dummy))	
-		(maphash (lambda (k v)
-			(declare (ignore k))
-			(setf (aref fields (rownum v)) v))									; Assign FIELD NAME to array matching the fields ROW NUMBER
-			table-fields)
+			(fvalues (make-array (length fields) :element-type t :initial-element 'null)))
+		(declare (ignore dummy))
 			
 		(cond 
 			((not table-fields)	(error "INSERT statement is malformed - missing correct table name"))

--- a/sql-tables.lsp
+++ b/sql-tables.lsp
@@ -45,7 +45,12 @@
 					(setf (gethash current-field (fields tbl))	; Make a new field instance in the table's FIELD hash-table and set ROWNUM to FIELD-NUM
 						(make-instance 'field :name current-field :rownum field-num))
 					(incf field-num))))							; Increment FIELD-NUM
-	tbl))				
+		(setf (fieldarr tbl) (make-array (hash-table-count (fields tbl)) :element-type t))
+		(maphash (lambda (k v)
+			(declare (ignore k))
+			(setf (aref (fieldarr tbl) (rownum v)) v))			; Assign FIELD reference to FIELDARR matching the fields' ROW NUMBER
+			(fields tbl))
+		tbl))				
 
 (defun create-table (stream)
 	"Create a table-form from STREAM, write it to files, and store it in the schema"


### PR DESCRIPTION
To reduce overhead of creating a FIELDARR with MAPHASH for every INSERT statement called.